### PR TITLE
Moved COMP cooldown and accrual into one transfer per user during `claimComp` [QSP-1] [QSP-4]

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -1237,16 +1237,17 @@ contract Comptroller is ComptrollerV6Storage, ComptrollerInterface, ComptrollerE
                 updateCompBorrowIndex(address(cToken), borrowIndex);
                 for (uint j = 0; j < holders.length; j++) {
                     distributeBorrowerComp(address(cToken), holders[j], borrowIndex);
-                    compAccrued[holders[j]] = grantCompCooldownInternal(holders[j], compAccrued[holders[j]]);
                 }
             }
             if (suppliers == true) {
                 updateCompSupplyIndex(address(cToken));
                 for (uint j = 0; j < holders.length; j++) {
                     distributeSupplierComp(address(cToken), holders[j]);
-                    compAccrued[holders[j]] = grantCompCooldownInternal(holders[j], compAccrued[holders[j]]);
                 }
             }
+        }
+        for (uint i = 0; i < holders.length; i++) {
+            compAccrued[holders[i]] = grantCompCooldownInternal(holders[i], compAccrued[holders[i]]);
         }
     }
 

--- a/spec/scenario/Flywheel/Cooldown.scen
+++ b/spec/scenario/Flywheel/Cooldown.scen
@@ -41,7 +41,23 @@ Macro InitSpeeds
     Comptroller SetCompSpeed cZRX 1
     Comptroller SetCompSpeed cBAT 1
     Comptroller RefreshCompSpeeds
+    Comptroller SetCompSpeed cBAT 1e18
     Comptroller Send "setCompAddress(address)" (Address COMP)
+
+Test "COMP from multiple tokens can be claimed frequently"
+    CooldownComptroller
+    InitSpeeds
+    Comptroller SetCooldownPeriod 2000
+    -- Make repeated claims, initiating cooldown for next period
+    FastForward 2000 Blocks
+    Comptroller ClaimComp Coburn
+    Assert Equal (Erc20 COMP TokenBalance Coburn) 0
+    FastForward 2000 Blocks
+    Comptroller ClaimComp Coburn
+    Assert Equal (Erc20 COMP TokenBalance Coburn) (3999999999999999999999)
+    FastForward 2000 Blocks
+    Comptroller ClaimComp Coburn
+    Assert Equal (Erc20 COMP TokenBalance Coburn) (7999999999999999999998)
 
 Test "COMP cooldown affects ability to claim"
     CooldownComptroller


### PR DESCRIPTION
**Bugs**:

- Fixed QSP-1
- Mitigated QSP-4